### PR TITLE
Added missing IAM permission

### DIFF
--- a/pages/guides/getting-started.mdx
+++ b/pages/guides/getting-started.mdx
@@ -38,7 +38,8 @@ The permissions your IAM user needs are
   "ses:SendRawEmail",
   "sqs:ReceiveMessage",
   "sqs:DeleteMessage",
-  "ses:GetSendQuota"
+  "ses:GetSendQuota",
+  "ses:GetAccount"
 ]  
 ```
 


### PR DESCRIPTION
When booting up a docker container of 00 i got a error stating that i was missing a permission.
This pr adds the permission to the `AWS setup` section.